### PR TITLE
Check checkboxes with selected options.

### DIFF
--- a/jquery.multicheckbox.js
+++ b/jquery.multicheckbox.js
@@ -40,7 +40,7 @@
           if ($option.data('label-class') != null) {
             label_class = " class=\"" + ($option.data('label-class')) + "\"";
           }
-          checkbox = "<label" + label_class + ">\n  <input type=\"checkbox\" value=\"" + ($option.val()) + "\" /> " + ($option.text()) + "\n</label>";
+          checkbox = "<label" + label_class + ">\n  <input type=\"checkbox\" value=\"" + ($option.val()) + "\"" + ($option.is(':selected') ? 'checked' : '') + " /> " + ($option.text()) + "\n</label>";
           return checkboxes += checkbox;
         });
         $container = $("<div class=\"multicheckbox-container" + (this.options['scroll_wrapper_enabled'] ? ' multicheckbox-wrap-container' : void 0) + "\">\n  " + checkboxes + "\n</div>");


### PR DESCRIPTION
This fix basically ensures that select elements with already selected values at page load have the associated checkboxes auto-checked. This is usually the case for forms where we need to edit data. 
For example `<select name="sectors[]" id="frmc_sectors" multiple="multiple" class="form-control">
<option value="9" selected="selected">Agriculture</option>
<option value="16">Poverty Alleviation</option>
<option value="11">Democracy</option>
<option value="2" selected="selected">Governance</option>
<option value="1" selected="selected">Health</option>
</select>`
